### PR TITLE
adds dependabot configuration and github workflows for samples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/1-Authentication/sign-in"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: maven
+  directory: "/1-Authentication/sign-in-b2c"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: maven
+  directory: "/2-Authorization-I/call-graph"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: maven
+  directory: "/3-Authorization-II/groups"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: maven
+  directory: "/3-Authorization-II/roles"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/workflows/1-Authentication-sign-in-b2c.yml
+++ b/.github/workflows/1-Authentication-sign-in-b2c.yml
@@ -1,0 +1,27 @@
+name: Sign-in B2C
+
+on:
+  push:
+    branches: [ main ]
+    paths: ['1-Authentication/sign-in-b2c/**', '.github/workflows/**']
+  pull_request:
+    branches: [ main ]
+    paths: ['1-Authentication/sign-in-b2c/**', '.github/workflows/**']
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      relativePath: ./1-Authentication/sign-in-b2c
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 16
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify
+        working-directory: ${{ env.relativePath }}

--- a/.github/workflows/1-Authentication-sign-in.yml
+++ b/.github/workflows/1-Authentication-sign-in.yml
@@ -1,0 +1,27 @@
+name: Sign-in Sample CI
+
+on:
+  push:
+    branches: [ main ]
+    paths: ['1-Authentication/sign-in/**', '.github/workflows/**']
+  pull_request:
+    branches: [ main ]
+    paths: ['1-Authentication/sign-in/**', '.github/workflows/**']
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      relativePath: ./1-Authentication/sign-in
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 16
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify
+        working-directory: ${{ env.relativePath }}

--- a/.github/workflows/2-Authorization-I-call-graph.yml
+++ b/.github/workflows/2-Authorization-I-call-graph.yml
@@ -1,0 +1,27 @@
+name: Call Graph Sample CI
+
+on:
+  push:
+    branches: [ main ]
+    paths: ['2-Authorization-I/call-graph/**', '.github/workflows/**']
+  pull_request:
+    branches: [ main ]
+    paths: ['2-Authorization-I/call-graph/**', '.github/workflows/**']
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      relativePath: ./2-Authorization-I/call-graph
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 16
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify
+        working-directory: ${{ env.relativePath }}

--- a/.github/workflows/3-Authorization-II-groups.yml
+++ b/.github/workflows/3-Authorization-II-groups.yml
@@ -1,0 +1,27 @@
+name: 3 II Groups Sample CI
+
+on:
+  push:
+    branches: [ main ]
+    paths: ['3-Authorization-II/groups/**', '.github/workflows/**']
+  pull_request:
+    branches: [ main ]
+    paths: ['3-Authorization-II/groups/**', '.github/workflows/**']
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      relativePath: ./3-Authorization-II/groups
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 16
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify
+        working-directory: ${{ env.relativePath }}

--- a/.github/workflows/3-Authorization-II-roles.yml
+++ b/.github/workflows/3-Authorization-II-roles.yml
@@ -1,0 +1,27 @@
+name: 3 II Roles Sample CI
+
+on:
+  push:
+    branches: [ main ]
+    paths: ['3-Authorization-II/roles/**', '.github/workflows/**']
+  pull_request:
+    branches: [ main ]
+    paths: ['3-Authorization-II/roles/**', '.github/workflows/**']
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      relativePath: ./3-Authorization-II/roles
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 16
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify
+        working-directory: ${{ env.relativePath }}


### PR DESCRIPTION
- adds a dependabot configuration for the samples
- adds workflows for the samples


The [Microsoft Graph SDK version in use](https://github.com/Azure-Samples/ms-identity-java-servlet-webapp-authentication/blob/157a8137627cd103c3d6cf1dc7fc90d81ba4259c/2-Authorization-I/call-graph/pom.xml#L49) is fairly outdated.
This PR adds a dependabot configuration so pull requests to upgrade dependencies are created automatically and github workflows so the samples are built automatically when such pull requests come in.
The maintainers will only have to review and merge the pull requests then.